### PR TITLE
support connection behavior

### DIFF
--- a/lib/ldap_ex/ELDAPv3.ex
+++ b/lib/ldap_ex/ELDAPv3.ex
@@ -7,7 +7,7 @@ defmodule LDAPEx.ELDAPv3 do
   """
 
   require Record
-  import Record, only: [defrecord: 2, extract_all: 1, is_record: 2]
+  import Record, only: [defrecord: 2, extract_all: 1]
 
 
   for rec <- extract_all(from: "lib/asn1/ELDAPv3a.hrl") do

--- a/lib/ldap_ex/client.ex
+++ b/lib/ldap_ex/client.ex
@@ -2,29 +2,9 @@ defmodule LDAPEx.Client do
   @moduledoc """
   This handles the LDAP communications over the TCP or SSL connections.
   """
-  use GenServer
-
-  require Logger
-
-  require LDAPEx.ELDAPv3
 
   require Record
   import Record, only: [is_record: 2]
-
-
-  @ldap_version 3
-
-  defstruct fd: nil, using_tls: false, id: 0, version: @ldap_version, config: %{}
-
-
-  defmodule LDAPException do
-    defexception type: :error, message: "<UNKNOWN LDAP EXCEPTION"
-  end
-
-
-  ### This file is heavily based off of Erlangs eldap package:
-  # https://github.com/erlang/otp/blob/e1489c448b7486cdcfec6a89fea238d88e6ce2f3/lib/eldap/src/eldap.erl
-
 
   ####
   #
@@ -40,13 +20,13 @@ defmodule LDAPEx.Client do
 
   ```elixir
 
-  iex> {:ok, ldap} = LDAPEx.Client.start_link()
-  iex> is_pid(ldap)
+  iex> {:ok, conn} = LDAPEx.Client.start_link()
+  iex> is_pid(conn)
   true
 
   # Anon login
-  iex> {:ok, ldap} = LDAPEx.Client.start_link(username: "", password: "")
-  iex> is_pid(ldap)
+  iex> {:ok, conn} = LDAPEx.Client.start_link(username: "", password: "")
+  iex> is_pid(conn)
   true
 
   iex> LDAPEx.Client.start_link(username: "INVALID", password: "")
@@ -55,51 +35,30 @@ defmodule LDAPEx.Client do
   iex> LDAPEx.Client.start_link(username: System.get_env("TEST_LDAP_DN"), password: "INCORRECT")
   {:error, :invalidCredentials}
 
+  OOTB creates the connection synchronously. Passing `async_conn: true` as an
+  override option makes this asynchronous.
   ```
   """
   def start_link(overrides \\ []) do
-    config = LDAPEx.Config.get_config(overrides)
-    # old_trap = Process.flag(:trap_exit, true)
-    # ret = try do
-    #   GenServer.start_link(__MODULE__, config)
-    # rescue
-    #   res -> {:RES, res}
-    # catch
-    #   :exit, res -> {:exit, res}
-    #   err -> {:ERR, err}
-    # end
-    # Process.flag(:trap_exit, old_trap)
-    # ret
-    try do
-      GenServer.start(__MODULE__, config)
-    catch
-      :exit, reason -> {:error, {:exit, reason}}
-    else
-      {:ok, pid} when is_pid(pid) ->
-        Process.link(pid)
-        {:ok, pid}
-      ret -> ret
-    end
+    LDAPEx.Conn.start_link(overrides)
   end
-
 
   @doc """
   This will close the supplied `LDAPEx.Client`.
 
   ```elixir
 
-  iex> {:ok, ldap} = LDAPEx.Client.start_link()
-  iex> is_pid(ldap)
+  iex> {:ok, conn} = LDAPEx.Client.start_link()
+  iex> is_pid(conn)
   true
-  iex> LDAPEx.Client.close(ldap)
+  iex> LDAPEx.Client.close(conn)
   :ok
 
   ```
   """
-  def close(ldap) when is_pid(ldap) do
-    GenServer.cast(ldap, :close)
+  def close(conn) when is_pid(conn) do
+    LDAPEx.Conn.stop(conn)
   end
-
 
   @doc """
   This sets up a search record, this should then be passed into
@@ -196,19 +155,8 @@ defmodule LDAPEx.Client do
   ```
   """
   def setup_search(searchRequestArgs \\ []) do
-    default = LDAPEx.ELDAPv3."SearchRequest"(
-      baseObject: :BASE_INVALID,
-      scope: v_scope(:wholeSubtree),
-      derefAliases: v_deref(:derefAlways),
-      sizeLimit: v_integer_nonneg(0, "sizeLimit"),
-      timeLimit: :undefined,
-      typesOnly: v_bool(false),
-      filter: :FILTER_INVALID,
-      attributes: v_attributes([])
-      )
-    parse_into_searchRequest(searchRequestArgs, default)
+    LDAPEx.Conn.setup_search(searchRequestArgs)
   end
-
 
   @doc """
   This performs a search in the LDAP connection using the record created by
@@ -216,23 +164,23 @@ defmodule LDAPEx.Client do
 
   ```elixir
 
-  iex> {:ok, ldap} = LDAPEx.Client.start_link()
+  iex> {:ok, conn} = LDAPEx.Client.start_link()
   iex> req = LDAPEx.Client.setup_search(baseObject: System.get_env("TEST_LDAP_DN"), filter: {:present, "objectClass"} )
-  iex> {:ok, {res, _references}} = LDAPEx.Client.search(ldap, req) # _refs are just an empty [] in every server tested so far...
+  iex> {:ok, {res, _references}} = LDAPEx.Client.search(conn, req) # _refs are just an empty [] in every server tested so far...
   iex> [r] = res # Assuming only one record is returned
   iex> r.objectName === System.get_env("TEST_LDAP_DN")
   true
   iex> map_size(r.attributes) >= 1
   true
-  iex> LDAPEx.Client.close(ldap)
+  iex> LDAPEx.Client.close(conn)
   :ok
 
   ```
   """
-  def search(ldap, searchRecord, genserver_timeout \\ 120000, controls \\ :asn1_NOVALUE) when is_pid(ldap) and is_record(searchRecord, :SearchRequest) do
-    GenServer.call(ldap, {:search, searchRecord, controls}, genserver_timeout)
+  def search(conn, searchRecord, genserver_timeout \\ 120000, controls \\ :asn1_NOVALUE)
+        when is_pid(conn) and is_record(searchRecord, :SearchRequest) do
+    LDAPEx.Conn.search(conn, searchRecord, genserver_timeout, controls)
   end
-
 
   @doc """
   This returns an object by a full object name, optionally can specify specific
@@ -243,455 +191,18 @@ defmodule LDAPEx.Client do
 
   ```elixir
 
-  iex> {:ok, ldap} = LDAPEx.Client.start_link()
-  iex> {:ok, obj} = LDAPEx.Client.get_object(ldap, System.get_env("TEST_LDAP_DN"))
+  iex> {:ok, conn} = LDAPEx.Client.start_link()
+  iex> {:ok, obj} = LDAPEx.Client.get_object(conn, System.get_env("TEST_LDAP_DN"))
   iex> obj.objectName === System.get_env("TEST_LDAP_DN")
   true
   iex> map_size(obj.attributes) >= 1
   true
-  iex> LDAPEx.Client.close(ldap)
+  iex> LDAPEx.Client.close(conn)
   :ok
 
   ```
   """
-  def get_object(ldap, dn, attributes \\ [], genserver_timeout \\ 120000) do
-    GenServer.call(ldap, {:get_object, dn, attributes}, genserver_timeout)
+  def get_object(conn, dn, attributes \\ [], genserver_timeout \\ 120000) do
+    LDAPEx.Conn.get_object(conn, dn, attributes, genserver_timeout)
   end
-
-
-
-  ####
-  #
-  # GenServer Callbacks
-  #
-  ####
-
-  # Don't call this one with login_at_connect: false yet, no way to log in yet if not now...
-  # def init(%{server: server, port: port, ssl: ssl, timeout: timeout, login_at_connect: false} = config) do
-  #   {:ok, connection} = try_connect(config)
-  #   state = %LDAPEx.Client{fd: connection, using_tls: ssl, config: config}
-  #   {:ok, state}
-  # end
-
-  def init(%{ssl: ssl, username: username, password: password} = config) do
-    {:ok, fd} = try_connect(config)
-    state = %LDAPEx.Client{fd: fd, using_tls: ssl, config: config}
-    case do_simple_bind(state, username, password, :asn1_NOVALUE) do
-      {:ok, newState} -> {:ok, put_in(newState.config[:password], nil)} # Sanitize password
-      {{:ok, {:referral, referral}}, _newState} ->
-        do_unbind(bump_id(state))
-        {:stop, {:referral, referral}}
-      {{:error, err}, _newState} ->
-        do_unbind(bump_id(state))
-        {:stop, err}
-    end
-  end
-
-
-  def handle_call({:search, searchRecord, controls}, _from, state) do
-    {res, newState} = do_search(bump_id(state), searchRecord, controls)
-    {:reply, res, newState}
-  end
-
-  def handle_call({:get_object, dn, attributes}, _from, state) do
-    {res, newState} = do_get_object(bump_id(state), dn, attributes)
-    {:reply, res, newState}
-  end
-
-
-  def handle_cast(:close, state) do
-    {:ok, newState} = do_unbind(bump_id(state))
-    {:stop, :normal, newState}
-  end
-
-  ####
-  #
-  # Internal functions
-  #
-  ####
-  defp bump_id(%{id: id} = state) do
-    %{state | id: bump_id_safe(id+1)}
-  end
-
-
-  defp bump_id_safe(id) when is_integer(id) and id>=0 and id<=2147483647 do
-    id+1
-  end
-  defp bump_id_safe(id) when is_integer(id) and id>2147483647 do
-    0 # Is it safe to wrap around?  Will this ever happen in reality?
-  end
-
-
-  defp ldap_closed_p(%{fd: fd, using_tls: true} = _state, emsg) do
-    ## Check if the SSL socket seems to be alive or not
-    try do
-      :ssl.sockname(fd)
-    rescue
-      _ -> {:error, :ldap_closed}
-    catch
-      _ -> {:error, :ldap_closed}
-    else
-      {:ok, _res} -> {:error, emsg}
-      {:error, _res} ->
-        :ssl.close(fd)
-        {:error, :ldap_closed}
-      #_ -> {:error, :ldap_closed}
-    end
-  end
-
-  defp ldap_closed_p(%{fd: fd, using_tls: false} = _state, emsg) do
-    ## Non-SSL socket
-    try do
-      :inet.port(fd)
-    rescue
-      _ -> {:error, :ldap_closed}
-    catch
-      _ -> {:error, :ldap_closed}
-    else
-      {:error, _res} -> {:error, :ldap_closed}
-      _ -> {:error, emsg}
-    end
-  end
-
-
-  defp try_connect(%{server: server, port: port, ssl: false, timeout: timeout}) do
-    tcpOpts = [:binary, packet: :asn1, active: false]
-    :gen_tcp.connect(to_charlist(server), port, tcpOpts, timeout)
-  end
-
-  defp try_connect(%{server: server, port: port, ssl: true, timeout: timeout}) do
-    tcpOpts = [:binary, packet: :asn1, active: false]
-    tlsOpts = []
-    :ssl.connect(server, port, tcpOpts ++ tlsOpts, timeout)
-  end
-
-
-  defp do_unbind(state) do
-    req = ""
-    send_request(state, {:unbindRequest, req})
-    do_final_unbind(state)
-    {:ok, %{state | fd: nil, using_tls: false}}
-  end
-
-
-  defp do_final_unbind(%{fd: fd, using_tls: false} = _state) do
-    :gen_tcp.close(fd)
-  end
-
-  defp do_final_unbind(%{fd: fd, using_tls: true} = _state) do
-    :ssl.close(fd)
-  end
-
-
-  ### Send an LDAP request and maybe get a response
-  defp request(state, request) do
-    send_request(state, request)
-    recv_response(state)
-  end
-
-
-  defp send_request(%{id: id} = state, {t, p}) do
-    send_the_LDAPMessage(state, LDAPEx.ELDAPv3."LDAPMessage"(messageID: id, protocolOp: {t, p}))
-  end
-
-  defp send_request(%{id: id} = state, {t, p, :asn1_NOVALUE}) do
-    send_the_LDAPMessage(state, LDAPEx.ELDAPv3."LDAPMessage"(messageID: id, protocolOp: {t, p}))
-  end
-
-  defp send_request(%{id: id} = state, {t, p, controls0}) do
-    controls = for {:control, f1, f2, f3} <- controls0 do
-      LDAPEx.ELDAPv3."Control"(controlType: f1, criticality: f2, controlValue: f3)
-    end
-    send_the_LDAPMessage(state, LDAPEx.ELDAPv3."LDAPMessage"(messageID: id, protocolOp: {t, p},
-      controls: controls))
-  end
-
-
-  defp send_the_LDAPMessage(state, ldapMessage) do
-    {:ok, bytes} = LDAPEx.ELDAPv3.encode(:LDAPMessage, ldapMessage)
-    case do_send(state, bytes) do
-      {:error, reason} -> raise LDAPException, type: :gen_tcp_error, message: reason
-      response -> response
-    end
-  end
-
-
-  defp do_send(%{fd: fd, using_tls: false}, bytes) do
-    :gen_tcp.send(fd, bytes)
-  end
-
-  defp do_send(%{fd: fd, using_tls: true}, bytes) do
-    :ssl.send(fd, bytes)
-  end
-
-
-  defp do_recv(%{fd: fd, using_tls: false, config: %{timeout: timeout}}, len) do
-    :gen_tcp.recv(fd, len, timeout)
-  end
-
-  defp do_recv(%{fd: fd, using_tls: true, config: %{timeout: timeout}}, len) do
-    :ssl.recv(fd, len, timeout)
-  end
-
-
-  defp recv_response(state) do
-    case do_recv(state, 0) do
-      {:ok, packet} ->
-        case LDAPEx.ELDAPv3.decode(:LDAPMessage, packet) do
-          {:ok, resp} -> {:ok, resp}
-          error -> raise LDAPException, type: :decode_error, message: error
-        end
-      {:error, reason} -> raise LDAPException, type: :gen_tcp_error, message: reason
-    end
-  end
-
-  ### The check_reply function is not used just yet...
-  # LDAPEx.ELDAPv3."LDAPMessage"(messageID: id, protocolOp: protocolOp)
-  # -record('LDAPMessage',{messageID, protocolOp, controls = asn1_NOVALUE}).
-  # {'LDAPMessage', messageID, protocolOp, controls = asn1_NOVALUE}
-  # defp check_reply(%{id: id} = state, {:ok, {:"LDAPMessage", id, protocolOp, _controls}=msg}, op) do
-  #   case protocolOp do
-  #     {^op, result} when is_record(result, :"LDAPResult") ->
-  #       #LDAPEx.ELDAPv3."LDAPResult"(resultCode: resultCode, referral: referral) = result
-  #       # -record('LDAPResult',{resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE}).
-  #       # {'LDAPResult', resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE}
-  #       {:"LDAPResult", resultCode, _matchedDN, _errorMessage, referral} = result
-  #       case resultCode do
-  #         :success -> {:ok, state}
-  #         :referral -> {{:ok, {:referral, referral}}, state}
-  #         error -> {:error, error}
-  #       end
-  #     error -> {:error, error}
-  #   end
-  # end
-  # Hmm, the below is a more complex matcher, but it is so much shorter and kind
-  # of more readable...
-  # defp check_reply(%{id: id} = state,
-  #   {:ok, {:LDAPMessage, id,
-  #     {op, {:LDAPResult, :success, _matchedDN, _errorMessage, _referral}}, _controls}=msg},
-  #     op) do
-  #       {:ok, state}
-  # end
-  # defp check_reply(%{id: id} = state,
-  #   {:ok, {:LDAPMessage, id,
-  #     {op, {:LDAPResult, :referral, _matchedDN, _errorMessage, referral}}, _controls}=msg},
-  #     op) do
-  #       {{:ok, {:referral, referral}}, state}
-  # end
-  # defp check_reply(_, error, _) do
-  #   {:error, error}
-  # end
-
-
-  ### Bind requests
-
-  defp do_simple_bind(state, dn, password, controls) do
-    exec_simple_bind(bump_id(state), dn, password, controls)
-  end
-
-
-  # -record('BindRequest',{version, name, authentication}).
-  # {'BindRequest', version, name, authentication}
-  defp exec_simple_bind(%{version: version} = state, dn, password, controls) do
-    #req = LDAPEx.ELDAPv3."BindRequest"(version: version, name: dn, authentication: {:simple, password}) # TODO:  Check if to_char_list is needed on these...
-    req = {:BindRequest, version, dn, {:simple, password}}
-    reply = request(state, {:bindRequest, req, controls})
-    exec_simple_bind_reply(state, reply)
-  end
-
-
-  # -record('LDAPMessage',{messageID, protocolOp, controls = asn1_NOVALUE}).
-  # {'LDAPMessage', messageID, protocolOp, controls = asn1_NOVALUE}
-  # -record('BindResponse',{resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE, serverSaslCreds = asn1_NOVALUE}).
-  # {'BindResponse', resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE, serverSaslCreds = asn1_NOVALUE}
-  defp exec_simple_bind_reply(%{id: messageID} = state,
-    {:ok, {:LDAPMessage, messageID, {:bindResponse,
-      {:BindResponse, resultCode, _matchedDN, _errorMessage, referral, _serverSaslCreds}}, _controls}}) do
-        case resultCode do
-          :success -> {:ok, state}
-          :referral -> {{:ok, {:referral, referral}}, state}
-          err -> {{:error, err}, state}
-        end
-  end
-
-  defp exec_simple_bind_reply(_, error) do
-    {:error, error}
-  end
-
-
-  ### Search setup
-
-  defp parse_into_searchRequest([], searchRequest) do
-    searchRequest
-  end
-  defp parse_into_searchRequest([{:baseObject, base}|rest], searchRequest) do
-    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, baseObject: base))
-  end
-  defp parse_into_searchRequest([{:scope, scope}|rest], searchRequest) do
-    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, scope: v_scope(scope)))
-  end
-  defp parse_into_searchRequest([{:derefAliases, derefAliases}|rest], searchRequest) do
-    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, derefAliases: v_deref(derefAliases)))
-  end
-  defp parse_into_searchRequest([{:sizeLimit, sizeLimit}|rest], searchRequest) do
-    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, sizeLimit: v_integer_nonneg(sizeLimit, "sizeLimit")))
-  end
-  defp parse_into_searchRequest([{:timeLimit, timeLimit}|rest], searchRequest) do
-    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, timeLimit: v_integer_nonneg(timeLimit, "timeLimit")))
-  end
-  defp parse_into_searchRequest([{:typesOnly, typesOnly}|rest], searchRequest) do
-    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, typesOnly: v_bool(typesOnly)))
-  end
-  defp parse_into_searchRequest([{:filter, filter}|rest], searchRequest) do
-    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, filter: v_filter(filter)))
-  end
-  defp parse_into_searchRequest([{:attributes, attributes}|rest], searchRequest) do
-    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, attributes: v_attributes(attributes)))
-  end
-
-
-  defp v_deref(:neverDerefAliases)   ,do: :neverDerefAliases
-  defp v_deref(:derefInSearching)    ,do: :derefInSearching
-  defp v_deref(:derefFindingBaseObj) ,do: :derefFindingBaseObj
-  defp v_deref(:derefAlways)         ,do: :derefAlways
-  defp v_deref(deref)                ,do: raise LDAPException, type: :invalid_deref, message: "unknown deref: #{deref}"
-
-  defp v_scope(:baseObject)   ,do: :baseObject
-  defp v_scope(:singleLevel)  ,do: :singleLevel
-  defp v_scope(:wholeSubtree) ,do: :wholeSubtree
-  defp v_scope(scope)         ,do: raise LDAPException, type: :invalid_scope, message: "unknown scope: #{scope}"
-
-  defp v_bool(true)  ,do: true
-  defp v_bool(false) ,do: false
-  defp v_bool(bool)  ,do: raise LDAPException, type: :invalid_bool, message: "not Boolean: #{bool}"
-
-  defp v_integer_nonneg(i, _type) when is_integer(i) and i>=0 and i<=2147483647 ,do: i
-  defp v_integer_nonneg(i, type) ,do: raise LDAPException, type: :invalid_nonneg_integer, message: "#{type} not positive integer between 0 and 2147483647: #{i}"
-
-  defp v_attributes(attrs) when is_list(attrs) do
-    attrs
-    |> Enum.map(fn
-      a when is_binary(a) or is_list(a) -> a
-      a -> raise LDAPException, type: :invalid_attribute, message: "attribute not a string: #{a}"
-    end)
-  end
-
-  defp v_filter({:and, l})             ,do: {:and, l}
-  defp v_filter({:or,  l})             ,do: {:or,  l}
-  defp v_filter({:not, l})             ,do: {:not, l}
-  defp v_filter({:equalityMatch, av})  ,do: {:equalityMatch, av}
-  defp v_filter({:greaterOrEqual, av}) ,do: {:greaterOrEqual, av}
-  defp v_filter({:lessOrEqual, av})    ,do: {:lessOrEqual, av}
-  defp v_filter({:approxMatch, av})    ,do: {:approxMatch, av}
-  defp v_filter({:present, a})         ,do: {:present, a}
-  defp v_filter({:substrings, s})      when is_record(s, :SubstringFilter)       ,do: {:substrings, s}
-  defp v_filter({:extensibleMatch, s}) when is_record(s, :MatchingRuleAssertion) ,do: {:extensibleMatch, s}
-  defp v_filter(filter)                ,do: raise LDAPException, type: :invalid_filter, message: "unknown filter: #{filter}"
-
-
-  ### Search
-
-  defp do_search(state, searchRecord, controls) do
-    searchRecord = add_search_timeout(state, searchRecord)
-    try do
-      collect_search_responses(state, searchRecord, controls)
-    rescue
-      e in LDAPException -> {ldap_closed_p(state, e), state}
-    catch
-      {:error, emsg}               -> {ldap_closed_p(state, emsg), state}
-      {:EXIT, err}                 -> {ldap_closed_p(state, err), state}
-      otherwise                    -> {ldap_closed_p(state, otherwise), state}
-    else
-      {:ok, res, ref, newState}    -> {{:ok, polish(res, ref)}, newState}
-      {{:ok, val}, newState}       -> {{:ok, val}, newState}
-      {{:error, reason}, newState} -> {{:error, reason}, newState}
-      #otherwise                    -> {ldap_closed_p(state, otherwise), state}
-    end
-  end
-
-
-  defp add_search_timeout(%{config: %{timeout: timeout}} = _state, searchRecord) do
-    LDAPEx.ELDAPv3."SearchRequest"(timeLimit: timeLimit) = searchRecord
-    case timeLimit do
-      :undefined -> LDAPEx.ELDAPv3."SearchRequest"(searchRecord, timeLimit: round(timeout/1000))
-      _ -> searchRecord
-    end
-  end
-
-
-  ###
-  ### Polish the returned search result
-  ###
-
-  defp polish(res, ref) do
-    r = polish_result(res)
-    ### No special treatment of referrals at the moment.
-    #eldap_search_result{entries = R,
-  	#	 referrals = Ref}.
-    {r, ref}
-  end
-
-  defp polish_result([h|t]) when is_record(h, :SearchResultEntry) do
-    LDAPEx.ELDAPv3."SearchResultEntry"(objectName: objectName, attributes: attributes) = h
-    f = fn {_, a, v} -> {a, v} end
-    attrs = Enum.map(attributes, f) |> Enum.into(%{})
-    [%{objectName: objectName, attributes: attrs} | polish_result(t)]
-  end
-  defp polish_result([]), do: []
-
-
-  ### The returned answers cames in one packet per entry
-  ### mixed with possible referals
-  defp collect_search_responses(state, searchRecord, controls) do
-    send_request(state, {:searchRequest, searchRecord, controls})
-    resp = recv_response(state)
-    collect_search_responses(state, resp, [], [])
-  end
-
-  # -record('LDAPMessage',{messageID, protocolOp, controls = asn1_NOVALUE}).
-  # {:LDAPMessage, messageID, protocolOp, controls = asn1_NOVALUE}}
-  # -record('LDAPResult',{resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE}).
-  # {:LDAPResult, resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE}
-  defp collect_search_responses(state, {:ok, msg}, acc, ref) when is_record(msg, :LDAPMessage) do
-    case elem(msg, 2) do
-      {:searchResDone, r} when is_record(r, :LDAPResult) ->
-        case elem(r, 1) do
-          :success -> {:ok, acc, ref, state}
-          :referral -> {{:ok, {:referral, elem(r, 4)}}, state}
-          reason -> {{:error, reason}, state}
-        end
-      {:searchResEntry, r} when is_record(r, :SearchResultEntry) ->
-        resp = recv_response(state)
-        collect_search_responses(state, resp, [r|acc], ref)
-      # {:searchResRef, r} ->
-      #   # This is entirely handled improperly, however does any LDAP server send these at all?
-      #   resp = recv_response(state)
-      #   collect_search_responses(state, resp, acc, [r|ref])
-      otherwise -> raise LDAPException, type: :search_failure, message: otherwise
-    end
-  end
-
-  defp collect_search_responses(_state, msg, _acc, _ref) do
-    raise LDAPException, type: :search_invalid, message: msg
-  end
-
-
-  ## Get Object
-
-  defp do_get_object(state, dn, attributes) do
-    searchRecord = LDAPEx.Client.setup_search(
-      baseObject: dn,
-      filter: {:present, "objectClass"},
-      attributes: attributes
-      )
-    case do_search(state, searchRecord, :asn1_NOVALUE) do
-      {{:ok, {[r], _refs}}, newState}                -> {{:ok, r}, newState}
-      {{:ok, {[], _refs}}, newState}                 -> {{:error, :no_object_found}, newState}
-      {{:ok, {[_r0, _r1 | _rest], _refs}}, newState} -> {{:error, :more_than_one_object_found}, newState}
-      {{:ok, _unknown}, newState}                    -> {{:error, :non_object}, newState}
-      {{:error, err}, newState}                      -> {{:error, err}, newState}
-      #{unknown, newState}                            -> {{:error, {:unknown_error, unknown}}, newState}
-    end
-  end
-
 end

--- a/lib/ldap_ex/conn.ex
+++ b/lib/ldap_ex/conn.ex
@@ -1,0 +1,564 @@
+defmodule LDAPEx.Conn do
+  ### This file is heavily based off of Erlangs eldap package:
+  # https://github.com/erlang/otp/blob/e1489c448b7486cdcfec6a89fea238d88e6ce2f3/lib/eldap/src/eldap.erl
+
+  @moduledoc false
+  use Connection
+
+  require Logger
+  require LDAPEx.ELDAPv3
+
+  require Record
+  import Record, only: [is_record: 2]
+
+  defmodule State do
+    @ldap_version 3
+    defstruct [
+      fd: nil,
+      id: 0,
+      backoff: nil,
+      using_tls: false,
+      config: %{},
+      version: @ldap_version
+    ]
+  end
+
+  defmodule LDAPException do
+    defexception type: :error, message: "<UNKNOWN LDAP EXCEPTION"
+  end
+
+
+  def start_link(ldap_opts \\ [], gs_opts \\ []) do
+    result = Connection.start_link(__MODULE__, ldap_opts, gs_opts)
+    Logger.log(:info, "start_link returns: #{inspect result}")
+    result
+  end
+
+  def stop(conn, timeout \\ :infinity) do
+    GenServer.stop(conn, :normal, timeout)
+  end
+
+  def setup_search(searchRequestArgs \\ []) do
+    default = LDAPEx.ELDAPv3."SearchRequest"(
+      baseObject: :BASE_INVALID,
+      scope: v_scope(:wholeSubtree),
+      derefAliases: v_deref(:derefAlways),
+      sizeLimit: v_integer_nonneg(0, "sizeLimit"),
+      timeLimit: :undefined,
+      typesOnly: v_bool(false),
+      filter: :FILTER_INVALID,
+      attributes: v_attributes([])
+      )
+    parse_into_searchRequest(searchRequestArgs, default)
+  end
+
+  def search(ldap, searchRecord, genserver_timeout \\ 120000, controls \\ :asn1_NOVALUE) when is_pid(ldap) and is_record(searchRecord, :SearchRequest) do
+    GenServer.call(ldap, {:search, searchRecord, controls}, genserver_timeout)
+  end
+
+  def get_object(ldap, dn, attributes \\ [], genserver_timeout \\ 120000) do
+    GenServer.call(ldap, {:get_object, dn, attributes}, genserver_timeout)
+  end
+
+
+  ####
+  #
+  # Callbacks
+  #
+  ####
+
+  def init(ldap_opts) do
+    state = %State{config: LDAPEx.Config.get_config(ldap_opts)}
+    if ldap_opts[:async_conn] == true do
+      {:connect, :initial_connection, state}
+    else
+      case do_connect(:initial_connection, state) do
+        {:ok, _state} = result -> result
+        {:error, reason, _state} -> {:stop, reason}
+      end
+    end
+  end
+
+  def connect(info, state) do
+    case do_connect(info, state) do
+      {:ok, state} ->
+        {:ok, %{state | backoff: nil, id: 0}}
+      {:error, reason, state} ->
+        if reason == :invalidCredentials do
+          {:stop, reason, state}
+        else
+          state = update_backoff(state)
+          {:backoff, state.backoff, state}
+        end
+    end
+  end
+
+  def disconnect({:error, reason}, state) do
+    Logger.log(:error, "LDAPEx disconnected: #{inspect reason}")
+    ldap_closed_p(state, reason)
+    {:connect, :reconnect, %{state | fd: nil, backoff: nil, id: 0}}
+  end
+
+  def terminate(reason, state) do
+    Logger.log(:info, "LDAPEx terminating connection: #{inspect reason}")
+    ldap_closed_p(state, reason)
+    :ok
+  end
+
+  def handle_call(_msg, _from, %{fd: nil} = state) do
+    {:reply, {:error, :not_connected}, state}
+  end
+
+  def handle_call({:search, searchRecord, controls}, _from, state) do
+    # {res, newState} = do_search(bump_id(state), searchRecord, controls)
+    # {:reply, res, newState}
+    case do_search(bump_id(state), searchRecord, controls) do
+      {{:error, :ldap_closed} = error, state} -> {:disconnect, error, error, state}
+      {result, state} -> {:reply, result, state}
+    end
+  end
+
+  def handle_call({:get_object, dn, attributes}, _from, state) do
+    # {res, newState} = do_get_object(bump_id(state), dn, attributes)
+    # {:reply, res, newState}
+    case do_get_object(bump_id(state), dn, attributes) do
+      {{:error, :ldap_closed} = error, state} -> {:disconnect, error, error, state}
+      {result, state} -> {:reply, result, state}
+    end
+  end
+
+  def handle_cast(:close, state) do
+    {:ok, newState} = do_unbind(bump_id(state))
+    {:stop, :normal, newState}
+  end
+
+
+  ####
+  #
+  # Internal functions
+  #
+  ####
+
+  defp do_connect(info, state) do
+    config = state.config
+    with {:ok, fd} <- try_connect(config),
+         Logger.log(:info, "LDAPEx port opened: #{inspect fd}"),
+         state = %{state | fd: fd, using_tls: config.ssl},
+         {:ok, state} <- do_simple_bind(state, config.username, config.password, :asn1_NOVALUE)
+    do
+      if info in [:backoff, :reconnect] do
+        Logger.log(:info, "LDAPEx reconnected: #{inspect fd}")
+      end
+      {:ok, %{state | backoff: nil, id: 0}}
+    else
+      {{:ok, {:referral, _referral}}, state} ->
+        {:ok, state} = do_unbind(bump_id(state))
+        {:error, :referral_unsupported, state}
+      {{:error, reason}, state} ->
+        {:ok, state} = do_unbind(bump_id(state))
+        {:error, reason, state}
+      {:error, reason} ->
+        Logger.log(:error, "LDAPEx failed to connect: #{inspect reason} - backoff: #{inspect state.backoff}")
+        {:error, reason, state}
+    end
+  end
+
+  defp try_connect(%{server: server, port: port, ssl: false, timeout: timeout}) do
+    tcpOpts = [:binary, packet: :asn1, active: false]
+    :gen_tcp.connect(to_charlist(server), port, tcpOpts, timeout)
+  end
+
+  defp try_connect(%{server: server, port: port, ssl: true, timeout: timeout}) do
+    tcpOpts = [:binary, packet: :asn1, active: false]
+    tlsOpts = []
+    :ssl.connect(server, port, tcpOpts ++ tlsOpts, timeout)
+  end
+
+  # TODO: Move to config
+  @backoff_min 1000
+  @backoff_max 30_000
+
+  defp update_backoff(state) do
+    backoff =
+      case state.backoff do
+        nil -> @backoff_min
+        backoff when backoff * 2 <= @backoff_max -> backoff * 2
+        _ -> @backoff_max
+      end
+    %{state | backoff: backoff}
+  end
+
+
+  defp ldap_closed_p(%{fd: fd, using_tls: true} = _state, emsg) do
+    ## Check if the SSL socket seems to be alive or not
+    try do
+      :ssl.sockname(fd)
+    rescue
+      _ -> {:error, :ldap_closed}
+    catch
+      _ -> {:error, :ldap_closed}
+    else
+      {:ok, _res} -> {:error, emsg}
+      {:error, _res} ->
+        :ssl.close(fd)
+        {:error, :ldap_closed}
+      #_ -> {:error, :ldap_closed}
+    end
+  end
+
+  defp ldap_closed_p(%{fd: fd, using_tls: false} = _state, emsg) do
+    ## Non-SSL socket
+    try do
+      :inet.port(fd)
+      Logger.log(:info, "LDAPEx port closed")
+    rescue
+      _ -> {:error, :ldap_closed}
+    catch
+      _ -> {:error, :ldap_closed}
+    else
+      {:error, _res} -> {:error, :ldap_closed}
+      _ -> {:error, emsg}
+    end
+  end
+
+
+  ####
+  #
+  # LDAP request/response functions
+  #
+  ####
+
+  ### Bind request
+
+  defp do_simple_bind(state, dn, password, controls) do
+    exec_simple_bind(bump_id(state), dn, password, controls)
+  end
+
+  # -record('BindRequest',{version, name, authentication}).
+  # {'BindRequest', version, name, authentication}
+  defp exec_simple_bind(%{version: version} = state, dn, password, controls) do
+    #req = LDAPEx.ELDAPv3."BindRequest"(version: version, name: dn, authentication: {:simple, password}) # TODO:  Check if to_char_list is needed on these...
+    req = {:BindRequest, version, dn, {:simple, password}}
+    reply = request(state, {:bindRequest, req, controls})
+    exec_simple_bind_reply(state, reply)
+  end
+
+
+  # -record('LDAPMessage',{messageID, protocolOp, controls = asn1_NOVALUE}).
+  # {'LDAPMessage', messageID, protocolOp, controls = asn1_NOVALUE}
+  # -record('BindResponse',{resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE, serverSaslCreds = asn1_NOVALUE}).
+  # {'BindResponse', resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE, serverSaslCreds = asn1_NOVALUE}
+  defp exec_simple_bind_reply(%{id: messageID} = state,
+    {:ok, {:LDAPMessage, messageID, {:bindResponse,
+      {:BindResponse, resultCode, _matchedDN, _errorMessage, referral, _serverSaslCreds}}, _controls}}) do
+        case resultCode do
+          :success -> {:ok, state}
+          :referral -> {{:ok, {:referral, referral}}, state}
+          err -> {{:error, err}, state}
+        end
+  end
+
+  defp exec_simple_bind_reply(_, error) do
+    {:error, error}
+  end
+
+
+  ### Unbind request
+
+  defp do_unbind(state) do
+    req = ""
+    send_request(state, {:unbindRequest, req})
+    do_final_unbind(state)
+    {:ok, %{state | fd: nil, using_tls: false}}
+  end
+
+  defp do_final_unbind(%{fd: fd, using_tls: false} = _state) do
+    :gen_tcp.close(fd)
+  end
+
+  defp do_final_unbind(%{fd: fd, using_tls: true} = _state) do
+    :ssl.close(fd)
+  end
+
+
+  ### Get Object request
+
+  defp do_get_object(state, dn, attributes) do
+    searchRecord = setup_search(
+      baseObject: dn,
+      filter: {:present, "objectClass"},
+      attributes: attributes
+      )
+    case do_search(state, searchRecord, :asn1_NOVALUE) do
+      {{:ok, {[r], _refs}}, newState}                -> {{:ok, r}, newState}
+      {{:ok, {[], _refs}}, newState}                 -> {{:error, :no_object_found}, newState}
+      {{:ok, {[_r0, _r1 | _rest], _refs}}, newState} -> {{:error, :more_than_one_object_found}, newState}
+      {{:ok, _unknown}, newState}                    -> {{:error, :non_object}, newState}
+      {{:error, err}, newState}                      -> {{:error, err}, newState}
+      #{unknown, newState}                            -> {{:error, {:unknown_error, unknown}}, newState}
+    end
+  end
+
+
+  ### Search setup
+
+  defp parse_into_searchRequest([], searchRequest) do
+    searchRequest
+  end
+  defp parse_into_searchRequest([{:baseObject, base}|rest], searchRequest) do
+    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, baseObject: base))
+  end
+  defp parse_into_searchRequest([{:scope, scope}|rest], searchRequest) do
+    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, scope: v_scope(scope)))
+  end
+  defp parse_into_searchRequest([{:derefAliases, derefAliases}|rest], searchRequest) do
+    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, derefAliases: v_deref(derefAliases)))
+  end
+  defp parse_into_searchRequest([{:sizeLimit, sizeLimit}|rest], searchRequest) do
+    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, sizeLimit: v_integer_nonneg(sizeLimit, "sizeLimit")))
+  end
+  defp parse_into_searchRequest([{:timeLimit, timeLimit}|rest], searchRequest) do
+    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, timeLimit: v_integer_nonneg(timeLimit, "timeLimit")))
+  end
+  defp parse_into_searchRequest([{:typesOnly, typesOnly}|rest], searchRequest) do
+    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, typesOnly: v_bool(typesOnly)))
+  end
+  defp parse_into_searchRequest([{:filter, filter}|rest], searchRequest) do
+    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, filter: v_filter(filter)))
+  end
+  defp parse_into_searchRequest([{:attributes, attributes}|rest], searchRequest) do
+    parse_into_searchRequest(rest, LDAPEx.ELDAPv3."SearchRequest"(searchRequest, attributes: v_attributes(attributes)))
+  end
+
+
+  defp v_deref(:neverDerefAliases)   ,do: :neverDerefAliases
+  defp v_deref(:derefInSearching)    ,do: :derefInSearching
+  defp v_deref(:derefFindingBaseObj) ,do: :derefFindingBaseObj
+  defp v_deref(:derefAlways)         ,do: :derefAlways
+  defp v_deref(deref)                ,do: raise LDAPException, type: :invalid_deref, message: "unknown deref: #{deref}"
+
+  defp v_scope(:baseObject)   ,do: :baseObject
+  defp v_scope(:singleLevel)  ,do: :singleLevel
+  defp v_scope(:wholeSubtree) ,do: :wholeSubtree
+  defp v_scope(scope)         ,do: raise LDAPException, type: :invalid_scope, message: "unknown scope: #{scope}"
+
+  defp v_bool(true)  ,do: true
+  defp v_bool(false) ,do: false
+  defp v_bool(bool)  ,do: raise LDAPException, type: :invalid_bool, message: "not Boolean: #{bool}"
+
+  defp v_integer_nonneg(i, _type) when is_integer(i) and i>=0 and i<=2147483647 ,do: i
+  defp v_integer_nonneg(i, type) ,do: raise LDAPException, type: :invalid_nonneg_integer, message: "#{type} not positive integer between 0 and 2147483647: #{i}"
+
+  defp v_attributes(attrs) when is_list(attrs) do
+    attrs
+    |> Enum.map(fn
+      a when is_binary(a) or is_list(a) -> a
+      a -> raise LDAPException, type: :invalid_attribute, message: "attribute not a string: #{a}"
+    end)
+  end
+
+  defp v_filter({:and, l})             ,do: {:and, l}
+  defp v_filter({:or,  l})             ,do: {:or,  l}
+  defp v_filter({:not, l})             ,do: {:not, l}
+  defp v_filter({:equalityMatch, av})  ,do: {:equalityMatch, av}
+  defp v_filter({:greaterOrEqual, av}) ,do: {:greaterOrEqual, av}
+  defp v_filter({:lessOrEqual, av})    ,do: {:lessOrEqual, av}
+  defp v_filter({:approxMatch, av})    ,do: {:approxMatch, av}
+  defp v_filter({:present, a})         ,do: {:present, a}
+  defp v_filter({:substrings, s})      when is_record(s, :SubstringFilter)       ,do: {:substrings, s}
+  defp v_filter({:extensibleMatch, s}) when is_record(s, :MatchingRuleAssertion) ,do: {:extensibleMatch, s}
+  defp v_filter(filter)                ,do: raise LDAPException, type: :invalid_filter, message: "unknown filter: #{filter}"
+
+
+  ### Search
+
+  defp do_search(state, searchRecord, controls) do
+    searchRecord = add_search_timeout(state, searchRecord)
+    try do
+      collect_search_responses(state, searchRecord, controls)
+    rescue
+      e in LDAPException -> {ldap_closed_p(state, e), state}
+    catch
+      {:error, emsg}               -> {ldap_closed_p(state, emsg), state}
+      {:EXIT, err}                 -> {ldap_closed_p(state, err), state}
+      otherwise                    -> {ldap_closed_p(state, otherwise), state}
+    else
+      {:ok, res, ref, newState}    -> {{:ok, polish(res, ref)}, newState}
+      {{:ok, val}, newState}       -> {{:ok, val}, newState}
+      {{:error, reason}, newState} -> {{:error, reason}, newState}
+      #otherwise                    -> {ldap_closed_p(state, otherwise), state}
+    end
+  end
+
+  defp add_search_timeout(%{config: %{timeout: timeout}} = _state, searchRecord) do
+    LDAPEx.ELDAPv3."SearchRequest"(timeLimit: timeLimit) = searchRecord
+    case timeLimit do
+      :undefined -> LDAPEx.ELDAPv3."SearchRequest"(searchRecord, timeLimit: round(timeout/1000))
+      _ -> searchRecord
+    end
+  end
+
+  ### Polish the returned search result
+  defp polish(res, ref) do
+    r = polish_result(res)
+    ### No special treatment of referrals at the moment.
+    #eldap_search_result{entries = R,
+  	#	 referrals = Ref}.
+    {r, ref}
+  end
+
+  defp polish_result([h|t]) when is_record(h, :SearchResultEntry) do
+    LDAPEx.ELDAPv3."SearchResultEntry"(objectName: objectName, attributes: attributes) = h
+    f = fn {_, a, v} -> {a, v} end
+    attrs = Enum.map(attributes, f) |> Enum.into(%{})
+    [%{objectName: objectName, attributes: attrs} | polish_result(t)]
+  end
+  defp polish_result([]), do: []
+
+  ### The returned answers cames in one packet per entry
+  ### mixed with possible referals
+  defp collect_search_responses(state, searchRecord, controls) do
+    send_request(state, {:searchRequest, searchRecord, controls})
+    resp = recv_response(state)
+    collect_search_responses(state, resp, [], [])
+  end
+
+  # -record('LDAPMessage',{messageID, protocolOp, controls = asn1_NOVALUE}).
+  # {:LDAPMessage, messageID, protocolOp, controls = asn1_NOVALUE}}
+  # -record('LDAPResult',{resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE}).
+  # {:LDAPResult, resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE}
+  defp collect_search_responses(state, {:ok, msg}, acc, ref) when is_record(msg, :LDAPMessage) do
+    case elem(msg, 2) do
+      {:searchResDone, r} when is_record(r, :LDAPResult) ->
+        case elem(r, 1) do
+          :success -> {:ok, acc, ref, state}
+          :referral -> {{:ok, {:referral, elem(r, 4)}}, state}
+          reason -> {{:error, reason}, state}
+        end
+      {:searchResEntry, r} when is_record(r, :SearchResultEntry) ->
+        resp = recv_response(state)
+        collect_search_responses(state, resp, [r|acc], ref)
+      # {:searchResRef, r} ->
+      #   # This is entirely handled improperly, however does any LDAP server send these at all?
+      #   resp = recv_response(state)
+      #   collect_search_responses(state, resp, acc, [r|ref])
+      otherwise -> raise LDAPException, type: :search_failure, message: otherwise
+    end
+  end
+
+  defp collect_search_responses(_state, msg, _acc, _ref) do
+    raise LDAPException, type: :search_invalid, message: msg
+  end
+
+
+  ### Core LDAP request/response handling
+
+  defp bump_id(%{id: id} = state) do
+    %{state | id: bump_id_safe(id+1)}
+  end
+
+  defp bump_id_safe(id) when is_integer(id) and id>=0 and id<=2147483647 do
+    id+1
+  end
+  defp bump_id_safe(id) when is_integer(id) and id>2147483647 do
+    0 # Is it safe to wrap around?  Will this ever happen in reality?
+  end
+
+  defp request(state, request) do
+    send_request(state, request)
+    recv_response(state)
+  end
+
+
+  defp send_request(%{id: id} = state, {t, p}) do
+    send_the_LDAPMessage(state, LDAPEx.ELDAPv3."LDAPMessage"(messageID: id, protocolOp: {t, p}))
+  end
+
+  defp send_request(%{id: id} = state, {t, p, :asn1_NOVALUE}) do
+    send_the_LDAPMessage(state, LDAPEx.ELDAPv3."LDAPMessage"(messageID: id, protocolOp: {t, p}))
+  end
+
+  defp send_request(%{id: id} = state, {t, p, controls0}) do
+    controls = for {:control, f1, f2, f3} <- controls0 do
+      LDAPEx.ELDAPv3."Control"(controlType: f1, criticality: f2, controlValue: f3)
+    end
+    send_the_LDAPMessage(state, LDAPEx.ELDAPv3."LDAPMessage"(messageID: id, protocolOp: {t, p},
+      controls: controls))
+  end
+
+
+  defp send_the_LDAPMessage(state, ldapMessage) do
+    {:ok, bytes} = LDAPEx.ELDAPv3.encode(:LDAPMessage, ldapMessage)
+    case do_send(state, bytes) do
+      {:error, reason} -> raise LDAPException, type: :gen_tcp_error, message: reason
+      response -> response
+    end
+  end
+
+
+  defp do_send(%{fd: fd, using_tls: false}, bytes) do
+    :gen_tcp.send(fd, bytes)
+  end
+
+  defp do_send(%{fd: fd, using_tls: true}, bytes) do
+    :ssl.send(fd, bytes)
+  end
+
+
+  defp recv_response(state) do
+    case do_recv(state, 0) do
+      {:ok, packet} ->
+        case LDAPEx.ELDAPv3.decode(:LDAPMessage, packet) do
+          {:ok, resp} -> {:ok, resp}
+          error -> raise LDAPException, type: :decode_error, message: error
+        end
+      {:error, reason} -> raise LDAPException, type: :gen_tcp_error, message: reason
+    end
+  end
+
+  defp do_recv(%{fd: fd, using_tls: false, config: %{timeout: timeout}}, len) do
+    :gen_tcp.recv(fd, len, timeout)
+  end
+
+  defp do_recv(%{fd: fd, using_tls: true, config: %{timeout: timeout}}, len) do
+    :ssl.recv(fd, len, timeout)
+  end
+
+
+  ### The check_reply function is not used just yet...
+  # LDAPEx.ELDAPv3."LDAPMessage"(messageID: id, protocolOp: protocolOp)
+  # -record('LDAPMessage',{messageID, protocolOp, controls = asn1_NOVALUE}).
+  # {'LDAPMessage', messageID, protocolOp, controls = asn1_NOVALUE}
+  # defp check_reply(%{id: id} = state, {:ok, {:"LDAPMessage", id, protocolOp, _controls}=msg}, op) do
+  #   case protocolOp do
+  #     {^op, result} when is_record(result, :"LDAPResult") ->
+  #       #LDAPEx.ELDAPv3."LDAPResult"(resultCode: resultCode, referral: referral) = result
+  #       # -record('LDAPResult',{resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE}).
+  #       # {'LDAPResult', resultCode, matchedDN, errorMessage, referral = asn1_NOVALUE}
+  #       {:"LDAPResult", resultCode, _matchedDN, _errorMessage, referral} = result
+  #       case resultCode do
+  #         :success -> {:ok, state}
+  #         :referral -> {{:ok, {:referral, referral}}, state}
+  #         error -> {:error, error}
+  #       end
+  #     error -> {:error, error}
+  #   end
+  # end
+  # Hmm, the below is a more complex matcher, but it is so much shorter and kind
+  # of more readable...
+  # defp check_reply(%{id: id} = state,
+  #   {:ok, {:LDAPMessage, id,
+  #     {op, {:LDAPResult, :success, _matchedDN, _errorMessage, _referral}}, _controls}=msg},
+  #     op) do
+  #       {:ok, state}
+  # end
+  # defp check_reply(%{id: id} = state,
+  #   {:ok, {:LDAPMessage, id,
+  #     {op, {:LDAPResult, :referral, _matchedDN, _errorMessage, referral}}, _controls}=msg},
+  #     op) do
+  #       {{:ok, {:referral, referral}}, state}
+  # end
+  # defp check_reply(_, error, _) do
+  #   {:error, error}
+  # end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule LDAPEx.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :asn1, :ssl],
+    [applications: [:logger, :asn1, :ssl, :connection],
      mod: {LDAPEx, []}]
   end
 
@@ -52,7 +52,8 @@ defmodule LDAPEx.Mixfile do
     [{:credo, "~> 0.8", only: [:dev]},
      {:dialyxir, "~> 0.5", only: [:dev]},
      {:earmark, "~> 1.2", only: [:dev]},
-     {:ex_doc, "~> 0.18", only: [:dev]}
+     {:ex_doc, "~> 0.18", only: [:dev]},
+     {:connection, "~> 1.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [], [], "hexpm"},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.8", "990e7844a8d06ebacd88744a55853a83b74270b8a8461c55a4d0334b8e1736c9", [], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},


### PR DESCRIPTION
Hi: Would like to use this lib in Noa OAuth provider for LDAP based authentication. It would be good to have this lib implement the `Connection` behavior.

https://hexdocs.pm/connection/Connection.html

Take a look at/review this PR. Made the required changes for this behavior.

The following two doc tests are failing with this change:

 1) test doc at LDAPEx.Client.start_link/1 (7) (LDAPExTest.Client)
     test/ldap_ex_client_test.exs:3
     ** (EXIT from #PID<0.217.0>) :invalidDNSyntax

  2) test doc at LDAPEx.Client.start_link/1 (8) (LDAPExTest.Client)
     test/ldap_ex_client_test.exs:3
     ** (EXIT from #PID<0.219.0>) :invalidCredentials

The existing implementation of Client.start_link is done in terms of separate start and link steps with the ability to get back an error return. With the Connection behavior the init callback sends a {:stop, reason}. This makes the above two tests fail.

Any suggesions? Feel free to make any changes appropriately and incorporate if this is useful. Thanks.