### PR TITLE
Merge pull request #3 from mbklein/ssl-charlist-bugfix

### DIFF
--- a/lib/ldap_ex/client.ex
+++ b/lib/ldap_ex/client.ex
@@ -362,7 +362,7 @@ defmodule LDAPEx.Client do
   defp try_connect(%{server: server, port: port, ssl: true, timeout: timeout}) do
     tcpOpts = [:binary, packet: :asn1, active: false]
     tlsOpts = []
-    :ssl.connect(server, port, tcpOpts ++ tlsOpts, timeout)
+    :ssl.connect(to_charlist(server), port, tcpOpts ++ tlsOpts, timeout)
   end
 
 


### PR DESCRIPTION
`try_connect(%{ssl: false})` properly converts server to charlist before connecting, but `try_connect(%{ssl: true})` doesn't, resulting in a connection error.